### PR TITLE
 allow recording of an arbitrary number of data streams

### DIFF
--- a/kiwiclient.py
+++ b/kiwiclient.py
@@ -92,7 +92,6 @@ class KiwiSDRStreamBase(object):
         self._version_major = None
         self._version_minor = None
         self._modulation = None
-
     def connect(self, host, port):
         # self._prepare_stream(host, port, 'SND')
         pass
@@ -109,7 +108,6 @@ class KiwiSDRStreamBase(object):
         self._socket = socket.socket()
         self._socket.settimeout(self._options.socket_timeout)
         self._socket.connect((host, port))
-
         uri = '/%d/%s' % (int(time.time()), which)
         handshake = wsclient.ClientHandshakeProcessor(self._socket, host, port)
         handshake.handshake(uri)
@@ -239,7 +237,6 @@ class KiwiSDRSoundStream(KiwiSDRStreamBase):
         rssi = (smeter & 0x0FFF) // 10 - 127
         if self._modulation == 'iq':
             gps = dict(zip(['last_gps_solution', 'dummy', 'gpssec', 'gpsnsec'], struct.unpack('<BBII', data[0:10])))
-            ## gps['gpsnsec'] = struct.unpack('<I', data[6:10])[0]
             data  = data[10:]
             count = len(data) // 2
             data  = struct.unpack('>%dh' % count, data)
@@ -274,7 +271,6 @@ class KiwiSDRSoundStream(KiwiSDRStreamBase):
 
     def run(self):
         """Run the client."""
-
         received = self._stream.receive_message()
         self._process_ws_message(received)
 

--- a/proc.m
+++ b/proc.m
@@ -1,21 +1,33 @@
 ## -*- octave -*-
 
-function [x,xx]=proc(fn) ##20171119T171520Z_30000_iq.wav
-  tic
-  [x,fs]=read_kiwi_iq_wav(fn);
-  toc;
+function [x,xx,fs,last_gpsfix]=proc(varargin)
+  if length(varargin) == 0
+    return
+  end
+  if length(varargin) >=1
+    fn = varargin(1);
+  end
+  max_last_gpsfix = 255;
+  if length(varargin) >=2
+    max_last_gpsfix = varargin(2){1,1};
+  end
 
-  idx = find(cat(1,x.gpslast)<6);
-  xx  = {};
-  for i=1:length(idx)
-    j=idx(i);
+  [x,fs]      = read_kiwi_iq_wav(fn);
+  last_gpsfix =  max(cat(1,x.gpslast));
+  idx         = find(cat(1,x.gpslast) < max_last_gpsfix);
+  xx          = {};
+  n = length(idx);
+  xx(n).t = [];
+  xx(n).z = [];
+  for i=1:n
+    j       = idx(i);
     xx(i).t = x(j).gpssec + 1e-9*x(j).gpsnsec + [0:length(x(j).z)-1]'/fs;
     xx(i).z = x(j).z;
   end
 
-  if length(xx) != 0
-    subplot(2,2,1:2); plot(mod(cat(1,xx.t), 1), abs(cat(1,xx.z)));                                  xlabel("GPS seconds mod 1 (sec)");
-    subplot(2,2,3);   plot(mod(cat(1,xx.t), 1), abs(cat(1,xx.z)), '.'); xlim([0.0285 0.0294]) ;     xlabel("GPS seconds mod 1 (sec)");
-    subplot(2,2,4);   plot(mod(cat(1,xx.t), 1), abs(cat(1,xx.z)), '.'); xlim(0.1+[0.0285 0.0294]) ; xlabel("GPS seconds mod 1 (sec)");
-  end
+#  if length(xx) != 0
+#    subplot(2,2,1:2); plot(mod(cat(1,xx.t), 1), abs(cat(1,xx.z)));                                  xlabel("GPS seconds mod 1 (sec)");
+#    subplot(2,2,3);   plot(mod(cat(1,xx.t), 1), abs(cat(1,xx.z)), '.'); xlim([0.0285 0.0294]) ;     xlabel("GPS seconds mod 1 (sec)");
+#    subplot(2,2,4);   plot(mod(cat(1,xx.t), 1), abs(cat(1,xx.z)), '.'); xlim(0.1+[0.0285 0.0294]) ; xlabel("GPS seconds mod 1 (sec)");
+#  end
 endfunction

--- a/proc.m
+++ b/proc.m
@@ -16,6 +16,9 @@ function [x,xx,fs,last_gpsfix]=proc(varargin)
   last_gpsfix =  max(cat(1,x.gpslast));
   idx         = find(cat(1,x.gpslast) < max_last_gpsfix);
   xx          = {};
+  if isempty(idx)
+    return
+  endif
   n = length(idx);
   xx(n).t = [];
   xx(n).z = [];

--- a/read_kiwi_iq_wav.cc
+++ b/read_kiwi_iq_wav.cc
@@ -74,43 +74,48 @@ DEFUN_DLD (read_kiwi_iq_wav, args, nargout, "[d,sample_rate]=read_kiwi_wav(\"<wa
       file.seekg(pos);
       file.read((char*)(&cr), sizeof(cr));
       if (cr.format() != "WAVE") {
-        // complain
+        error("'WAVE' chunk expected");
         break;
       }
+      const int n = (int(cr.size())-sizeof(chunk_riff)-4)/2074;
+      cell_z.resize(n);
+      cell_last.resize(n);
+      cell_gpssec.resize(n);
+      cell_gpsnsec.resize(n);
     } else if (c.id() == "fmt ") {
       file.seekg(pos);
       file.read((char*)(&fmt), sizeof(fmt));
       if (fmt.format() != 1 ||
           fmt.num_channels() != 2) {
-        // complain
+        error("unsupported WAVE format");
         break;
       }
-      retval(1) = octave_value(fmt.sample_rate());
+      retval(1) = fmt.sample_rate();
     } else if (c.id() == "data") {
-      ComplexNDArray a(dim_vector(c.size()/4, 1));
+      const int n = c.size()/4;
+      ComplexNDArray a(dim_vector(n, 1));
       int16_t i=0, q=0;
-      for (int j=0; j<c.size()/4 && file; ++j) {
+      for (int j=0; j<n && file; ++j) {
         file.read((char*)(&i), sizeof(i));
         file.read((char*)(&q), sizeof(q));
         a(j) = std::complex<double>(i/32768., q/32768.);
       }
-      cell_z(data_counter++) = octave_value(a);
+      cell_z(data_counter++) = a;
     } else if (c.id() == "kiwi") {
       file.seekg(pos);
       chunk_kiwi kiwi;
       file.read((char*)(&kiwi), sizeof(kiwi));
-      cell_last(data_counter)    = octave_value(kiwi.last());
-      cell_gpssec(data_counter)  = octave_value(kiwi.gpssec());
-      cell_gpsnsec(data_counter) = octave_value(kiwi.gpsnsec());
+      cell_last(data_counter)    = kiwi.last();
+      cell_gpssec(data_counter)  = kiwi.gpssec();
+      cell_gpsnsec(data_counter) = kiwi.gpsnsec();
     } else {
-      std::cout << "skipping unknown chunk " << c.id() << std::endl;
+      octave_stdout << "skipping unknown chunk " << c.id() << std::endl;
       pos = file.tellg();
       file.seekg(pos + c.size());
     }
   }
-
   octave_map map;
-  map.setfield("z",       cell_z);
+  map.setfield("z", cell_z);
   if (cell_last.length() == cell_z.length()) {
     map.setfield("gpslast", cell_last);
     map.setfield("gpssec",  cell_gpssec);


### PR DESCRIPTION
New command-line options:

```
Usage: kiwirecorder.py [options]

Options:
  -h, --help            show this help message and exit
  --log-level=LOG_LEVEL, --log_level=LOG_LEVEL
                        Log level: debug|info|warn|error|critical
  -k SOCKET_TIMEOUT, --socket-timeout=SOCKET_TIMEOUT, --socket_timeout=SOCKET_TIMEOUT
                        Timeout(sec) for sockets
  -s SERVER_HOST, --server-host=SERVER_HOST
                        server host (can be a comma-delimited list)
  -p SERVER_PORT, --server-port=SERVER_PORT
                        server port, default 8073 (can be a comma delimited
                        list)
  -f FREQUENCY, --freq=FREQUENCY
                        Frequency to tune to, in kHz (can be a comma-separated
                        list)
  -m MODULATION, --modulation=MODULATION
                        Modulation; one of am, lsb, usb, cw, nbfm, iq
  -L LP_CUT, --lp-cutoff=LP_CUT
                        Low-pass cutoff frequency, in Hz.
  -H HP_CUT, --hp-cutoff=HP_CUT
                        Low-pass cutoff frequency, in Hz.
  --station=STATION     Station ID to be appended (can be a comma-separated
                        list)
  -T THRESH, --threshold=THRESH
                        Squelch threshold, in dB.
  -w, --kiwi-wav        wav file format including KIWI header (GPS time-
                        stamps) only for IQ mode
  -g AGC_GAIN, --agc-gain=AGC_GAIN
                        AGC gain; if set, AGC is turned off (can be a comma-
                        separated list)

```