### PR TITLE
added the possibility to start new files every dt seconds

### DIFF
--- a/kiwirecorder.py
+++ b/kiwirecorder.py
@@ -110,7 +110,10 @@ class KiwiSoundRecorder(kiwiclient.KiwiSDRStream):
         """Output to a file on the disk."""
         # print '_write_samples', args
         now = time.gmtime()
-        if self._start_ts is None or (self._options.filename == '' and self._start_ts.tm_hour != now.tm_hour):
+        sec_of_day = lambda x: 3600*x.tm_hour + 60*x.tm_min + x.tm_sec
+        if self._start_ts is None or (self._options.filename == '' and
+                                      self._options.dt != 0 and
+                                      sec_of_day(now)/self._options.dt != sec_of_day(self._start_ts)/self._options.dt):
             self._start_ts = now
             self._start_time = time.time()
             # Write a static WAV header
@@ -249,6 +252,10 @@ def main():
                       dest='modulation',
                       type='string', default='am',
                       help='Modulation; one of am, lsb, usb, cw, nbfm, iq')
+    parser.add_option('--dt-sec',
+                      dest='dt',
+                      type='int', default=0,
+                      help='start a new file when mod(sec_of_day,dt) == 0')
     parser.add_option('-L', '--lp-cutoff',
                       dest='lp_cut',
                       type='float', default=100,


### PR DESCRIPTION
- default behavior: at the start of recording one file is opened and samples are written to it as long as the kiwirecorder is running
- with the option `-dt-sec=120` new files are started whenever sec_of_day%120 == 0, _i.e._, every two minutes starting at 00:00. This may be useful for making automatic recordings for WSPR reception.