### PR TITLE
Compensate for the filter offset in CW mode

### DIFF
--- a/kiwi/client.py
+++ b/kiwi/client.py
@@ -221,6 +221,9 @@ class KiwiSDRStream(KiwiSDRStreamBase):
                                     hc =  5000 if hc == None else hc
                                 else:
                                     raise KiwiUnknownModulation('"%s"' % mod)
+        if mod == 'cw':
+            # Compensate for the filter offset in CW mode
+            freq -= (lc + hc) / 2.0 / 1000.0
         self._send_message('SET mod=%s low_cut=%d high_cut=%d freq=%.3f' % (mod, lc, hc, freq))
 
     def set_agc(self, on=False, hang=False, thresh=-100, slope=6, decay=1000, gain=50):


### PR DESCRIPTION
In CW mode, the server offsets the frequency passed in the "SET mod"
message to the center of the filter; the browser client compensates for
this behavior. However, kiwiclient wasn't doing this, resulting in CW
recordings being made considerably off frequency (+500 Hz by default).