### PR TITLE
add examples and help text to kiwirecorder.py documentation

### DIFF
--- a/kiwirecorder.py
+++ b/kiwirecorder.py
@@ -390,7 +390,34 @@ def join_threads(snd, wf):
     [t.join() for t in threading.enumerate() if t is not threading.currentThread()]
 
 def main():
-    parser = OptionParser()
+    # extend the OptionParser so that we can print multiple paragraphs in
+    # the help text
+    class MyParser(OptionParser):
+        def format_description(self, formatter):
+            result = []
+            for paragraph in self.description:
+                result.append(formatter.format_description(paragraph))
+            return "\n".join(result[:-1]) # drop last \n
+
+        def format_epilog(self, formatter):
+            result = []
+            for paragraph in self.epilog:
+                result.append(formatter.format_epilog(paragraph))
+            return "".join(result)
+
+    usage = "%prog -s SERVER -p PORT -f FREQ -m MODE [other options]"
+    description = ["kiwirecorder.py records data from one or more KiwiSDRs to your disk."
+                   " It takes a number of options as inputs, the most basic of which"
+                   " are shown above.",
+                   "To record data from multiple Kiwis at once, use the same syntax,"
+              " but pass a list of values (where applicable) instead of a single value."
+              " Each list of values should be comma-delimited and without spaces."
+              " For instance, to record one Kiwi at localhost on port 80, and another Kiwi"
+              " at example.com port 8073, run the following:",
+              "    kiwirecorder.py -s localhost,example.com -p 80,8073 -f 10000,10000 -m am",
+              "In this example, both Kiwis will record on 10,000 kHz (10 MHz) in AM mode."]
+    epilog = [] # text here would go after the options list
+    parser = MyParser(usage=usage, description=description, epilog=epilog)
     parser.add_option('-s', '--server-host',
                       dest='server_host', type='string',
                       default='localhost', help='Server host (can be a comma-delimited list)',


### PR DESCRIPTION
kiwirecorder is quite useful to the ham radio research group I'm a part of, so I wanted to contribute to it. I've added explanatory text to the output of `--help`.

I noticed there's several kiwiclient repositories on GitHub, so I'm not sure who's I should contribute to, but I'm sending it to your repository because it looks to be the most recently-updated.