### PR TITLE
add kiwiclientd program

### DIFF
--- a/kiwi/client.py
+++ b/kiwi/client.py
@@ -116,7 +116,22 @@ class KiwiSDRStreamBase(object):
         self._version_major = None
         self._version_minor = None
         self._modulation = None
+        self._lowcut = 0
+        self._highcut = 0
+        self._frequency = 0
         self._stream = None
+
+    def get_mod(self):
+        return self._modulation
+
+    def get_lowcut(self):
+        return self._lowcut
+
+    def get_highcut(self):
+        return self._highcut
+
+    def get_frequency(self):
+        return self._frequency
 
     def connect(self, host, port):
         # self._prepare_stream(host, port, 'SND')
@@ -182,6 +197,9 @@ class KiwiSDRStream(KiwiSDRStreamBase):
         self._version_major = None
         self._version_minor = None
         self._modulation = None
+        self._lowcut = 0
+        self._highcut = 0
+        self._frequency = 0
         self._compression = True
         self._gps_pos = [0,0]
         self._s_meter_avgs = self._s_meter_cma = 0
@@ -226,6 +244,9 @@ class KiwiSDRStream(KiwiSDRStreamBase):
                                 else:
                                     raise KiwiUnknownModulation('"%s"' % mod)
         self._send_message('SET mod=%s low_cut=%d high_cut=%d freq=%.3f' % (mod, lc, hc, freq))
+        self._lowcut = lc
+        self._highcut = hc
+        self._frequency = freq
 
     def set_agc(self, on=False, hang=False, thresh=-100, slope=6, decay=1000, gain=50):
         self._send_message('SET agc=%d hang=%d thresh=%d slope=%d decay=%d manGain=%d' % (on, hang, thresh, slope, decay, gain))

--- a/kiwi/client.py
+++ b/kiwi/client.py
@@ -381,7 +381,7 @@ class KiwiSDRStream(KiwiSDRStreamBase):
                 self._meas_count += 1
                 self._tot_meas_count += 1
                 ts = time.strftime('%d-%b-%Y %H:%M:%S UTC ', time.gmtime()) if self._options.tstamp else ''
-                print("%sRSSI: %6.1f %d" % (ts, rssi, self._options.tstamp))
+                logging.debug("%sRSSI: %6.1f %d" % (ts, rssi, self._options.tstamp))
                 if not self._options.sound:
                     return
             else:

--- a/kiwi/rigctld.py
+++ b/kiwi/rigctld.py
@@ -31,6 +31,9 @@ class rigsocket(socket.socket):
             self.buffer = ""
             return ""
 
+        if len(self.buffer) == 0:
+            return ""
+
         # the buffer contains one or more complete commands
         if self.buffer[-1] == "\n":
             result = self.buffer

--- a/kiwi/rigctld.py
+++ b/kiwi/rigctld.py
@@ -63,13 +63,12 @@ class Rigctld(object):
             splitcmd = command.split()
             mod = splitcmd[1]
             try:
-                hc = splitcmd[2]
+                hc = int(splitcmd[2])
             except:
                 hc = None
-            # lc = self._kiwisdrstream._lowcut
             freq = self._kiwisdrstream.get_frequency()
             # print("calling set_mod", mod, lc, hc, freq)
-            self._kiwisdrstream.set_mod(mod, lc, hc, freq)
+            self._kiwisdrstream.set_mod(mod, None, hc, freq)
             return "RPRT 0\n"
         except:
             return "RPRT -1\n"

--- a/kiwi/rigctld.py
+++ b/kiwi/rigctld.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python
+#
+# Emulates a subset of the hamlib rigctld interface, allowing programs
+# like fldigi and wsjtx to query and change the frequency and mode of
+# a kiwisdr channel.
+#
+# The subset of commands corresponds to the commands actually used by
+# fldigi and wsjtx.
+#
+# (C) 2020 Rik van Riel <riel@surriel.com>
+# Released under the GNU General Public License (GPL) version 2 or newer
+
+import array
+import logging
+import socket
+import struct
+import time
+import select
+
+class Rigctld(object):
+    def __init__(self, kiwisdrstream=None, port=None, ipaddr=None):
+        self._kiwisdrstream = kiwisdrstream
+        self._listenport = port
+        self._clientsockets = []
+        # default localhost on port 6400
+        if port == None:
+            port = 6400
+        if ipaddr == None:
+            ipaddr = "127.0.0.1"
+
+        try:
+            socket.inet_aton(ipaddr)
+            addr = (ipaddr, port)
+            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        except socket.error:
+            addr = (ipaddr, port, 0, 0)
+            s = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        s.setblocking(0)
+
+        try:
+            s.bind(addr)
+        except socket.error:
+            logging.error("could not bind to port ", port)
+            s.close()
+            raise
+
+        s.listen()
+        self._serversocket = s
+
+    def _set_modulation(self, command):
+        # The M (set modulation) command has two parameters:
+        # M <mode> <passband>
+        # mode is mandatory, passband is optional
+        try:
+            splitcmd = command.split()
+            mod = splitcmd[1]
+            try:
+                hc = splitcmd[2]
+            except:
+                hc = None
+            # lc = self._kiwisdrstream._lowcut
+            freq = self._kiwisdrstream.get_frequency()
+            # print("calling set_mod", mod, lc, hc, freq)
+            self._kiwisdrstream.set_mod(mod, lc, hc, freq)
+            return "RPRT 0\n"
+        except:
+            return "RPRT -1\n"
+            
+    def _set_frequency(self, command):
+        try:
+            # hamlib freq is in Hz, kiwisdr in kHz
+            newfreq = command[2:]
+            freq = float(newfreq) / 1000
+            mod = self._kiwisdrstream.get_mod()
+            lc = self._kiwisdrstream.get_lowcut()
+            hc = self._kiwisdrstream.get_highcut()
+            # print("calling set_mod ", mod, lc, hc, freq)
+            self._kiwisdrstream.set_mod(mod, lc, hc, freq)
+            return "RPRT 0\n"
+        except:
+            return "RPRT -1\n"
+
+    def _dump_state(self):
+        # hamlib expects this large table of rig info when connecting
+        rigctlver = "1\n"
+        rig_model = "2\n"
+        itu_region = "0\n"
+        freqs = "0.000000 30000000.000000"
+        modes = "0x2f"  # AM LSB USB CW (NB)FM see hamlib/rig.h
+        # no tx power, one VFO per channel, one antenna
+        rx_range = "{} {} -1 -1 0x1 0x1\n".format(freqs, modes)
+        rx_end = "0 0 0 0 0 0 0\n"
+        tx_range = ""
+        tx_end = "0 0 0 0 0 0 0\n"
+        tuningsteps = ""
+        for step in ["1", "100", "1000", "5000", "9000", "10000"]:
+            tuningsteps += "{} {}\n".format(modes, step)
+        steps_end = "0 0\n"
+        ssbfilt = "0xc 2200\n"
+        cwfilt = "0x2 500\n"
+        amfilt = "0x1 6000\n"
+        fmfilt = "0x20 12000\n"
+        filt_end = "0 0\n"
+        max_rit = "0\n"
+        max_xit = "0\n"
+        max_ifshift = "0\n"
+        announces = "0\n"
+        get_func = "0\n"
+        set_func = "0\n"
+        get_level = "0\n"
+        set_level = "0\n"
+        get_parm = "0\n"
+        set_parm = "0\n"
+        preamp = "0 \n"
+        attenuator = "0 \n"
+        vfo_ops = "vfo_ops=0x0\n"
+        ptt_type = "ptt_type=0x0\n"
+        done = "done\n"
+
+        message = rigctlver + rig_model + itu_region
+        message += rx_range + rx_end + tx_range + tx_end
+        message += tuningsteps + steps_end
+        message += ssbfilt + cwfilt + amfilt + fmfilt + filt_end
+        message += max_rit + max_xit + max_ifshift + announces
+        message += get_func + set_func + get_level + set_level
+        message += get_parm + set_parm
+        message += preamp + attenuator + vfo_ops + ptt_type + done
+
+        return message
+
+    def _handle_command(self, sock, command):
+        if command.startswith('q'):
+            # quit
+            try:
+                sock.send("RPRT 0\n".encode('ASCII'))
+                sock.close()
+                self._clientsockets.remove(sock)
+            except:
+                pass
+            return "RPRT 0\n"
+        elif command.startswith('\chk_vfo'):
+            return "CHKVFO 0\n"
+        elif command.startswith('\dump_state'):
+            return self._dump_state()
+        elif command.startswith('f'):
+            # get frequency
+            freqinhz = int(self._kiwisdrstream.get_frequency() * 1000)
+            return "{}\n".format(freqinhz)
+        elif command.startswith('F'):
+            return self._set_frequency(command)
+        elif command.startswith('m'):
+            # get modulation
+            highcut = int(self._kiwisdrstream._highcut)
+            mod = self._kiwisdrstream._modulation
+            return "{}\n{}\n".format(mod, highcut)
+        elif command.startswith('M'):
+            return self._set_modulation(command)
+        elif command.startswith('s'):
+            # get split mode
+            return "0\nVFOA\n"
+        elif command.startswith('v'):
+            return "VFOA\n"
+            
+        print("Received unknown command: ", command)
+        return "RPRT 0\n"
+ 
+    def run(self):
+        # first accept a new connection, if there is any
+        try:
+            sock, addr = self._serversocket.accept()
+            self._clientsockets.append(sock)
+        except socket.error:
+            # no new connections this time
+            pass
+
+        # check for incoming traffic on existing connections
+        read_list = self._clientsockets
+        readable, writable, errored = select.select(read_list, [], [], 0)
+
+        for s in errored:
+            s.close()
+            self._clientsockets.remove(s)
+
+        for s in readable:
+            # TODO: add one-char-at-a-time write delay handling
+            try:
+                command = s.recv(4096)
+                try:
+                    command = command.decode('ASCII')
+                except:
+                    # someone sent non-ASCII, just ignore them
+                    continue
+            except socket.error:
+                continue
+
+            if len(command) > 0:
+                reply = ""
+                # sometimes hamlib programs send multiple commands at once
+                for line in command.splitlines():
+                    reply += self._handle_command(s, command)
+            else:
+                continue
+
+            try:
+                reply = reply.encode('ASCII')
+                s.send(reply)
+            except socket.error:
+                continue
+# EOF

--- a/kiwi/rigctld.py
+++ b/kiwi/rigctld.py
@@ -84,7 +84,7 @@ class Rigctld(object):
 
     def _dump_state(self):
         # hamlib expects this large table of rig info when connecting
-        rigctlver = "1\n"
+        rigctlver = "0\n"
         rig_model = "2\n"
         itu_region = "0\n"
         freqs = "0.000000 30000000.000000"
@@ -107,14 +107,14 @@ class Rigctld(object):
         max_xit = "0\n"
         max_ifshift = "0\n"
         announces = "0\n"
-        get_func = "0\n"
-        set_func = "0\n"
-        get_level = "0\n"
-        set_level = "0\n"
-        get_parm = "0\n"
-        set_parm = "0\n"
-        preamp = "0 \n"
-        attenuator = "0 \n"
+        preamp = "\n"
+        attenuator = "\n"
+        get_func = "0x0\n"
+        set_func = "0x0\n"
+        get_level = "0x0\n"
+        set_level = "0x0\n"
+        get_parm = "0x0\n"
+        set_parm = "0x0\n"
         vfo_ops = "vfo_ops=0x0\n"
         ptt_type = "ptt_type=0x0\n"
         done = "done\n"
@@ -124,9 +124,9 @@ class Rigctld(object):
         message += tuningsteps + steps_end
         message += ssbfilt + cwfilt + amfilt + fmfilt + filt_end
         message += max_rit + max_xit + max_ifshift + announces
+        message += preamp + attenuator
         message += get_func + set_func + get_level + set_level
-        message += get_parm + set_parm
-        message += preamp + attenuator + vfo_ops + ptt_type + done
+        message += get_parm + set_parm + vfo_ops + ptt_type + done
 
         return message
 
@@ -141,7 +141,7 @@ class Rigctld(object):
                 pass
             return "RPRT 0\n"
         elif command.startswith('\chk_vfo'):
-            return "CHKVFO 0\n"
+            return "0\n"
         elif command.startswith('\dump_state'):
             return self._dump_state()
         elif command.startswith('f'):

--- a/kiwi/rigctld.py
+++ b/kiwi/rigctld.py
@@ -153,8 +153,8 @@ class Rigctld(object):
         elif command.startswith('m'):
             # get modulation
             highcut = int(self._kiwisdrstream._highcut)
-            mod = self._kiwisdrstream._modulation
-            return "{}\n{}\n".format(mod, highcut)
+            mod = self._kiwisdrstream.get_mod()
+            return "{}\n{}\n".format(mod.upper(), highcut)
         elif command.startswith('M'):
             return self._set_modulation(command)
         elif command.startswith('s'):

--- a/kiwi/rigctld.py
+++ b/kiwi/rigctld.py
@@ -49,6 +49,12 @@ class Rigctld(object):
         s.listen()
         self._serversocket = s
 
+    def close(self):
+        for s in self._clientsockets:
+            s.close()
+            self._clientsockets.remove(s)
+        self._serversocket.close()
+
     def _set_modulation(self, command):
         # The M (set modulation) command has two parameters:
         # M <mode> <passband>

--- a/kiwi_nc.py
+++ b/kiwi_nc.py
@@ -309,6 +309,7 @@ def main():
     options.no_api = False
     options.connect_retries = 0
     options.connect_timeout = 3
+    options.rigctl_enabled = False
     gopt = options
     multiple_connections,options = options_cross_product(options)
 

--- a/kiwiclientd.py
+++ b/kiwiclientd.py
@@ -1,0 +1,399 @@
+#!/usr/bin/env python
+## -*- python -*-
+
+import array, logging, os, struct, sys, time, copy, threading, os
+import gc
+import math
+import soundcard as sc
+import numpy as np
+from copy import copy
+from traceback import print_exc
+from kiwi import KiwiSDRStream, KiwiWorker
+from optparse import OptionParser
+from optparse import OptionGroup
+
+HAS_RESAMPLER = True
+try:
+    ## if available use libsamplerate for resampling
+    from samplerate import Resampler
+except ImportError:
+    ## otherwise linear interpolation is used
+    HAS_RESAMPLER = False
+
+class KiwiSoundRecorder(KiwiSDRStream):
+    def __init__(self, options):
+        super(KiwiSoundRecorder, self).__init__()
+        self._options = options
+        self._type = 'SND'
+        freq = options.frequency
+        options.S_meter = False
+        #logging.info("%s:%s freq=%d" % (options.server_host, options.server_port, freq))
+        self._freq = freq
+        self._start_ts = None
+        self._start_time = None
+        self._squelch = Squelch(self._options) if options.thresh is not None else None
+        self._num_channels = 2 if options.modulation == 'iq' else 1
+        self._last_gps = dict(zip(['last_gps_solution', 'dummy', 'gpssec', 'gpsnsec'], [0,0,0,0]))
+        self._resampler = None
+        self._speaker = sc.get_speaker(options.sounddevice)
+        self._output_sample_rate = 0
+        if self._speaker is None:
+            if options.sounddevice is None:
+                print('Using default sound device. Specify --sound-device?')
+                options.sounddevice = 'default'
+            else:
+                print("Could not find %s, using default", options.sounddevice)
+            self._speaker = sc.default_speaker()
+
+
+    def _setup_rx_params(self):
+        self.set_name(self._options.user)
+        mod    = self._options.modulation
+        lp_cut = self._options.lp_cut
+        hp_cut = self._options.hp_cut
+        if mod == 'am':
+            # For AM, ignore the low pass filter cutoff
+            lp_cut = -hp_cut if hp_cut is not None else hp_cut
+        self.set_mod(mod, lp_cut, hp_cut, self._freq)
+        if self._options.agc_gain != None:
+            self.set_agc(on=False, gain=self._options.agc_gain)
+        else:
+            self.set_agc(on=True)
+        if self._options.compression is False:
+            self._set_snd_comp(False)
+        if self._options.nb is True:
+            gate = self._options.nb_gate
+            if gate < 100 or gate > 5000:
+                gate = 100
+            thresh = self._options.nb_thresh
+            if thresh < 0 or thresh > 100:
+                thresh = 50
+            self.set_noise_blanker(gate, thresh)
+        self._output_sample_rate = int(self._sample_rate)
+        if self._options.resample > 0:
+            self._output_sample_rate = self._options.resample
+            self._ratio = float(self._output_sample_rate)/self._sample_rate
+            logging.info('resampling from %g to %d Hz (ratio=%f)' % (self._sample_rate, self._options.resample, self._ratio))
+            if not HAS_RESAMPLER:
+                logging.info("libsamplerate not available: linear interpolation is used for low-quality resampling. "
+                             "(pip install samplerate)")
+        self._player = self._speaker.player(samplerate=int(self._output_sample_rate), blocksize=4096)
+        self._player.__enter__()
+
+    def _process_audio_samples(self, seq, samples, rssi):
+        if self._options.quiet is False:
+            sys.stdout.write('\rBlock: %08x, RSSI: %6.1f' % (seq, rssi))
+            sys.stdout.flush()
+
+        if self._options.resample > 0:
+            if HAS_RESAMPLER:
+                ## libsamplerate resampling
+                if self._resampler is None:
+                    self._resampler = Resampler(converter_type='sinc_best')
+                samples = np.round(self._resampler.process(samples, ratio=self._ratio)).astype(np.int16)
+            else:
+                ## resampling by linear interpolation
+                n  = len(samples)
+                xa = np.arange(round(n*self._ratio))/self._ratio
+                xp = np.arange(n)
+                samples = np.round(np.interp(xa,xp,samples)).astype(np.int16)
+
+
+        # Convert the int16 samples [-32768,32,767] to the floating point
+        # samples [-1.0,1.0] SoundCard expects
+        fsamples = samples.astype(np.float32)
+        fsamples /= 32768
+        self._player.play(fsamples)
+
+    def _on_sample_rate_change(self):
+        if self._options.resample is 0:
+            if self._output_sample_rate == int(self._sample_rate):
+                return
+            # reinitialize player if the playback sample rate changed
+            if hasattr(self, 'player'):
+                self._player.__exit__(exc_type=None, exc_value=None, traceback=None)
+            self._output_sample_rate = int(self._sample_rate)
+            self._player = self._speaker.player(samplerate=self._output_sample_rate, blocksize=4096)
+            self._player.__enter__()
+
+def options_cross_product(options):
+    """build a list of options according to the number of servers specified"""
+    def _sel_entry(i, l):
+        """if l is a list, return the element with index i, else return l"""
+        return l[min(i, len(l)-1)] if type(l) == list else l
+
+    l = []
+    multiple_connections = 0
+    for i,s in enumerate(options.server_host):
+        opt_single = copy(options)
+        opt_single.server_host = s
+        opt_single.status = 0
+
+        # time() returns seconds, so add pid and host index to make timestamp unique per connection
+        opt_single.timestamp = int(time.time() + os.getpid() + i) & 0xffffffff
+        for x in ['server_port', 'password', 'tlimit_password', 'frequency', 'agc_gain', 'station', 'user']:
+            opt_single.__dict__[x] = _sel_entry(i, opt_single.__dict__[x])
+        l.append(opt_single)
+        multiple_connections = i
+    return multiple_connections,l
+
+def get_comma_separated_args(option, opt, value, parser, fn):
+    values = [fn(v.strip()) for v in value.split(',')]
+    setattr(parser.values, option.dest, values)
+##    setattr(parser.values, option.dest, map(fn, value.split(',')))
+
+def join_threads(snd):
+    [r._event.set() for r in snd]
+    [t.join() for t in threading.enumerate() if t is not threading.currentThread()]
+
+def main():
+    # extend the OptionParser so that we can print multiple paragraphs in
+    # the help text
+    class MyParser(OptionParser):
+        def format_description(self, formatter):
+            result = []
+            for paragraph in self.description:
+                result.append(formatter.format_description(paragraph))
+            return "\n".join(result[:-1]) # drop last \n
+
+        def format_epilog(self, formatter):
+            result = []
+            for paragraph in self.epilog:
+                result.append(formatter.format_epilog(paragraph))
+            return "".join(result)
+
+    usage = "%prog -s SERVER -p PORT -f FREQ -m MODE [other options]"
+    description = ["kiwiclientd.py receives audio from a KiwiSDR and plays"
+                   " it to a (virtual) sound device. This can be used to"
+                   " send KiwiSDR audio to various programs to decode the"
+                   " received signals."
+                   " This program also accepts hamlib rigctl commands over"
+                   " a network socket to change the kiwisdr frequency",""]
+    epilog = [] # text here would go after the options list
+    parser = MyParser(usage=usage, description=description, epilog=epilog)
+    parser.add_option('-s', '--server-host',
+                      dest='server_host', type='string',
+                      default='localhost', help='Server host (can be a comma-separated list)',
+                      action='callback',
+                      callback_args=(str,),
+                      callback=get_comma_separated_args)
+    parser.add_option('-p', '--server-port',
+                      dest='server_port', type='string',
+                      default=8073, help='Server port, default 8073 (can be a comma-separated list)',
+                      action='callback',
+                      callback_args=(int,),
+                      callback=get_comma_separated_args)
+    parser.add_option('--pw', '--password',
+                      dest='password', type='string', default='',
+                      help='Kiwi login password (if required, can be a comma-separated list)',
+                      action='callback',
+                      callback_args=(str,),
+                      callback=get_comma_separated_args)
+    parser.add_option('--tlimit-pw', '--tlimit-password',
+                      dest='tlimit_password', type='string', default='',
+                      help='Connect time limit exemption password (if required, can be a comma-separated list)',
+                      action='callback',
+                      callback_args=(str,),
+                      callback=get_comma_separated_args)
+    parser.add_option('-u', '--user',
+                      dest='user', type='string', default='kiwiclientd',
+                      help='Kiwi connection user name (can be a comma-separated list)',
+                      action='callback',
+                      callback_args=(str,),
+                      callback=get_comma_separated_args)
+    parser.add_option('--log', '--log-level', '--log_level', type='choice',
+                      dest='log_level', default='warn',
+                      choices=['debug', 'info', 'warn', 'error', 'critical'],
+                      help='Log level: debug|info|warn(default)|error|critical')
+    parser.add_option('-q', '--quiet',
+                      dest='quiet',
+                      default=False,
+                      action='store_true',
+                      help='Don\'t print progress messages')
+    parser.add_option('--tlimit', '--time-limit',
+                      dest='tlimit',
+                      type='float', default=None,
+                      help='Record time limit in seconds. Ignored when --dt-sec used.')
+    parser.add_option('--launch-delay', '--launch_delay',
+                      dest='launch_delay',
+                      type='int', default=0,
+                      help='Delay (secs) in launching multiple connections')
+    parser.add_option('--connect-retries', '--connect_retries',
+                      dest='connect_retries', type='int', default=0,
+                      help='Number of retries when connecting to host (retries forever by default)')
+    parser.add_option('--connect-timeout', '--connect_timeout',
+                      dest='connect_timeout', type='int', default=15,
+                      help='Retry timeout(sec) connecting to host')
+    parser.add_option('-k', '--socket-timeout', '--socket_timeout',
+                      dest='socket_timeout', type='int', default=10,
+                      help='Socket timeout(sec) during data transfers')
+    parser.add_option('--OV',
+                      dest='ADC_OV',
+                      default=False,
+                      action='store_true',
+                      help='Print "ADC OV" message when Kiwi ADC is overloaded')
+    parser.add_option('-v', '-V', '--version',
+                      dest='krec_version',
+                      default=False,
+                      action='store_true',
+                      help='Print version number and exit')
+
+    group = OptionGroup(parser, "Audio connection options", "")
+    group.add_option('-f', '--freq',
+                      dest='frequency',
+                      type='string', default=1000,
+                      help='Frequency to tune to, in kHz (can be a comma-separated list)',
+                      action='callback',
+                      callback_args=(float,),
+                      callback=get_comma_separated_args)
+    group.add_option('-m', '--modulation',
+                      dest='modulation',
+                      type='string', default='am',
+                      help='Modulation; one of am, lsb, usb, cw, nbfm, iq (default passband if -L/-H not specified)')
+    group.add_option('--ncomp', '--no_compression',
+                      dest='compression',
+                      default=True,
+                      action='store_false',
+                      help='Don\'t use audio compression')
+    group.add_option('-L', '--lp-cutoff',
+                      dest='lp_cut',
+                      type='float', default=None,
+                      help='Low-pass cutoff frequency, in Hz')
+    group.add_option('-H', '--hp-cutoff',
+                      dest='hp_cut',
+                      type='float', default=None,
+                      help='High-pass cutoff frequency, in Hz')
+    group.add_option('-r', '--resample',
+                      dest='resample',
+                      type='int', default=0,
+                      help='Resample output file to new sample rate in Hz. The resampling ratio has to be in the range [1/256,256]')
+    group.add_option('-T', '--squelch-threshold',
+                      dest='thresh',
+                      type='float', default=None,
+                      help='Squelch threshold, in dB.')
+    group.add_option('--squelch-tail',
+                      dest='squelch_tail',
+                      type='float', default=1,
+                      help='Time for which the squelch remains open after the signal is below threshold.')
+    group.add_option('-g', '--agc-gain',
+                      dest='agc_gain',
+                      type='string',
+                      default=None,
+                      help='AGC gain; if set, AGC is turned off (can be a comma-separated list)',
+                      action='callback',
+                      callback_args=(float,),
+                      callback=get_comma_separated_args)
+    group.add_option('--nb',
+                      dest='nb',
+                      action='store_true', default=False,
+                      help='Enable noise blanker with default parameters.')
+    group.add_option('--nb-gate',
+                      dest='nb_gate',
+                      type='int', default=100,
+                      help='Noise blanker gate time in usec (100 to 5000, default 100)')
+    group.add_option('--nb-th', '--nb-thresh',
+                      dest='nb_thresh',
+                      type='int', default=50,
+                      help='Noise blanker threshold in percent (0 to 100, default 50)')
+    parser.add_option_group(group)
+
+    group = OptionGroup(parser, "Sound device options", "")
+    group.add_option('--snddev', '--sound-device',
+                      dest='sounddevice',
+                      type='string', default='',
+                      help='Sound device to play kiwi audio on')
+    group.add_option('--ls-snd', '--list-sound-devices',
+                      dest='list_sound_devices',
+                      default=False,
+                      action='store_true',
+                      help='List available sound devices and exit')
+    parser.add_option_group(group)
+
+    group = OptionGroup(parser, "Rig control options", "")
+    group.add_option('--rigctl', '--enable-rigctl',
+                      dest='rigctl_enabled',
+                      default=True,
+                      action='store_true',
+                      help='Enable rigctld backend for frequency changes.')
+    group.add_option('--rigctl-port', '--rigctl-port',
+                      dest='rigctl_port',
+                      type='int', default='6400',
+                      help='Port listening for rigctl commands (default 6400)')
+    group.add_option('--rigctl-addr', '--rigctl-address',
+                      dest='rigctl_address',
+                      type='string', default=None,
+                      help='Address to listen on (default 127.0.0.1)')
+    parser.add_option_group(group)
+
+    (options, unused_args) = parser.parse_args()
+
+    ## clean up OptionParser which has cyclic references
+    parser.destroy()
+    
+    if options.krec_version:
+        print('kiwiclientd v1.0')
+        sys.exit()
+
+    if options.list_sound_devices:
+        print(sc.all_speakers())
+        sys.exit();
+
+    FORMAT = '%(asctime)-15s pid %(process)5d %(message)s'
+    logging.basicConfig(level=logging.getLevelName(options.log_level.upper()), format=FORMAT)
+    if options.log_level.upper() == 'DEBUG':
+        gc.set_debug(gc.DEBUG_SAVEALL | gc.DEBUG_LEAK | gc.DEBUG_UNCOLLECTABLE)
+
+    run_event = threading.Event()
+    run_event.set()
+
+    if options.tlimit is not None and options.dt != 0:
+        print('Warning: --tlimit ignored when --dt-sec option used')
+
+    options.sdt = 0
+    options.dir = None
+    options.raw = False
+    options.sound = True
+    options.no_api = False
+    options.tstamp = False
+    options.station = None
+    options.filename = None
+    options.test_mode = False
+    options.is_kiwi_wav = False
+    options.is_kiwi_tdoa = False
+    gopt = options
+    multiple_connections,options = options_cross_product(options)
+
+    snd_recorders = []
+    for i,opt in enumerate(options):
+        opt.multiple_connections = multiple_connections
+        opt.idx = i
+        snd_recorders.append(KiwiWorker(args=(KiwiSoundRecorder(opt),opt,run_event)))
+
+    try:
+        for i,r in enumerate(snd_recorders):
+            if opt.launch_delay != 0 and i != 0 and options[i-1].server_host == options[i].server_host:
+                time.sleep(opt.launch_delay)
+            r.start()
+            #logging.info("started sound recorder %d, timestamp=%d" % (i, options[i].timestamp))
+            logging.info("started sound recorder %d" % i)
+
+        while run_event.is_set():
+            time.sleep(.1)
+
+    except KeyboardInterrupt:
+        run_event.clear()
+        join_threads(snd_recorders)
+        print("KeyboardInterrupt: threads successfully closed")
+    except Exception as e:
+        print_exc()
+        run_event.clear()
+        join_threads(snd_recorders)
+        print("Exception: threads successfully closed")
+
+    logging.debug('gc %s' % gc.garbage)
+
+if __name__ == '__main__':
+    #import faulthandler
+    #faulthandler.enable()
+    main()
+# EOF

--- a/kiwiclientd.py
+++ b/kiwiclientd.py
@@ -38,8 +38,8 @@ class KiwiSoundRecorder(KiwiSDRStream):
         self._output_sample_rate = 0
 
     def _init_player(self):
-        # if hasattr(self, 'player'):
-        #    self._player.__exit__(exc_type=None, exc_value=None, traceback=None)
+        if hasattr(self, 'player'):
+            self._player.__exit__(exc_type=None, exc_value=None, traceback=None)
         options = self._options
         speaker = sc.get_speaker(options.sounddevice)
         rate = self._output_sample_rate

--- a/kiwiclientd.py
+++ b/kiwiclientd.py
@@ -59,7 +59,7 @@ class KiwiSoundRecorder(KiwiSDRStream):
                 break
             except Exception as ex:
                 print("speaker.player failed with ", ex)
-                sleep(0.1)
+                time.sleep(0.1)
                 pass
 
     def _setup_rx_params(self):

--- a/kiwifax.py
+++ b/kiwifax.py
@@ -731,6 +731,7 @@ def main():
     options.timestamp = int(time.time() + os.getpid()) & 0xffffffff
     options.raw = False
     options.S_meter = -1
+    options.rigctl_enabled = False
 
     # Setup logging
     fmtr = logging.Formatter('%(asctime)s %(levelname)s: %(message)s', '%Y%m%dT%H%MZ')

--- a/kiwirecorder.py
+++ b/kiwirecorder.py
@@ -652,6 +652,7 @@ def main():
         print('Warning: --tlimit ignored when --dt-sec option used')
 
     options.raw = False
+    options.rigctl_enabled = False
     gopt = options
     multiple_connections,options = options_cross_product(options)
 

--- a/kiwiwfrecorder.py
+++ b/kiwiwfrecorder.py
@@ -188,6 +188,7 @@ def main():
     ## clean up OptionParser which has cyclic references
     parser.destroy()
 
+    opt.rigctl_enabled = False
     opt.is_kiwi_tdoa = False
     opt.connect_retries = 3
     opt.connect_timeout = 3


### PR DESCRIPTION
This program can stream sound from a kiwisdr channel to a virtual or real sound card, using the python SoundCard library, and also emulates a hamlib rigctld backend, which allows programs like fldigi, wsjtx or similar to query and change the frequency and mode.

It can be used to stream sound from multiple kiwisdr channels to multiple sound cards at the same time, using a command like this:

$ kiwiclientd.py -s kiwisdr.example.com -p 8073 -f 10000 -m usb --snddev
kiwisnd0,kiwisnd1 --rigctl-port 6400,6401

The SoundCard library works with Windows, MacOS, and Linux (pulseaudio).

