### PR TITLE
reconnect with the same frequency after getting disconnected

### DIFF
--- a/kiwi/client.py
+++ b/kiwi/client.py
@@ -118,7 +118,7 @@ class KiwiSDRStreamBase(object):
         self._modulation = None
         self._lowcut = 0
         self._highcut = 0
-        self._frequency = 0
+        self._freq = 0
         self._stream = None
 
     def get_mod(self):
@@ -131,7 +131,7 @@ class KiwiSDRStreamBase(object):
         return self._highcut
 
     def get_frequency(self):
-        return self._frequency
+        return self._freq
 
     def connect(self, host, port):
         # self._prepare_stream(host, port, 'SND')
@@ -199,7 +199,7 @@ class KiwiSDRStream(KiwiSDRStreamBase):
         self._modulation = None
         self._lowcut = 0
         self._highcut = 0
-        self._frequency = 0
+        self._freq = 0
         self._compression = True
         self._gps_pos = [0,0]
         self._s_meter_avgs = self._s_meter_cma = 0
@@ -246,7 +246,7 @@ class KiwiSDRStream(KiwiSDRStreamBase):
         self._send_message('SET mod=%s low_cut=%d high_cut=%d freq=%.3f' % (mod, lc, hc, freq))
         self._lowcut = lc
         self._highcut = hc
-        self._frequency = freq
+        self._freq = freq
 
     def set_agc(self, on=False, hang=False, thresh=-100, slope=6, decay=1000, gain=50):
         self._send_message('SET agc=%d hang=%d thresh=%d slope=%d decay=%d manGain=%d' % (on, hang, thresh, slope, decay, gain))

--- a/kiwiclientd.py
+++ b/kiwiclientd.py
@@ -29,6 +29,9 @@ class KiwiSoundRecorder(KiwiSDRStream):
         options.S_meter = False
         #logging.info("%s:%s freq=%d" % (options.server_host, options.server_port, freq))
         self._freq = freq
+        self._modulation = self._options.modulation
+        self._lowcut = self._options.lp_cut
+        self._highcut = self._options.hp_cut
         self._start_ts = None
         self._start_time = None
         self._squelch = Squelch(self._options) if options.thresh is not None else None
@@ -64,13 +67,11 @@ class KiwiSoundRecorder(KiwiSDRStream):
 
     def _setup_rx_params(self):
         self.set_name(self._options.user)
-        mod    = self._options.modulation
-        lp_cut = self._options.lp_cut
-        hp_cut = self._options.hp_cut
-        if mod == 'am':
+        lowcut = self._lowcut
+        if self._modulation == 'am':
             # For AM, ignore the low pass filter cutoff
-            lp_cut = -hp_cut if hp_cut is not None else hp_cut
-        self.set_mod(mod, lp_cut, hp_cut, self._freq)
+            lowcut = -self._highcut if lowcut is not None else lowcut
+        self.set_mod(self._modulation, lowcut, self._highcut, self._freq)
         if self._options.agc_gain != None:
             self.set_agc(on=False, gain=self._options.agc_gain)
         else:

--- a/kiwiclientd.py
+++ b/kiwiclientd.py
@@ -1,5 +1,14 @@
 #!/usr/bin/env python
 ## -*- python -*-
+#
+# Streams sound from a kiwisdr channel to a (virtual or not) sound card,
+# allowing the user to process kiwisdr signals with programs like fldigi,
+# wsjtx, etc.
+# Provides a hamlib rictld backend to change frequency and modulation of
+# the kiwisdr channel.
+#
+# Uses the SoundCard python module, which can stream sound to
+# coreaudio (MacOS), mediafoundation (Windows), and pulseaudio (Linux)
 
 import array, logging, os, struct, sys, time, copy, threading, os
 import gc


### PR DESCRIPTION
    Make kiwiclient remember what frequency it is on with the same
    variable name in both kiwiclientd.py and kiwi/client.py, and
    have _setup_rx_params use the remembered frequency when reconnecting.
    
    Tested by starting the script, changing the frequency through the
    rigctld interface, kicking the connection from the kiwisdr admin
    page, and watching it reconnect on the same frequency.

Also, add some documentation to the top of kiwiclientd.py