### PR TITLE
full AGC configuration via a YAML file

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ It provides the following methods which can be used in derived classes:
 * The complete list of options can be obtained by `python kiwirecorder.py --help`.
 * It is possible to record from more than one KiwiSDR simultaneously, see again `--help`.
 * For recording IQ samples there is the `-w` or `--kiwi-wav` option: this write	a .wav file which includes GNSS	timestamps (see below).
+* AGC options can be specified in a YAML-formatted file, `--agc-yaml` option, see `default_agc.yaml`.
 
 ## IQ .wav files with GNSS timestamps
 ### kiwirecorder.py configuration

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The following demo programs are provided. Use the `--help` argument to see all p
 * `kiwirecorder`: Record audio to WAV files, with squelch. Option `--wf` prints various waterfall statistics.
 * `kiwiwfrecorder`: Specialty program. Saves waterfall data and GPS timestamps to .npy format file.
 * `kiwifax`: Decode radiofax and save as PNGs, with auto start, stop, and phasing.
-* `kiwiclientd`: Plays Kiwi audio on sound cards (real & virtual) for use by programs like fldigi and wsjtx.  
+* `kiwiclientd`: Plays Kiwi audio on sound cards (real & virtual) for use by programs like fldigi and wsjtx.
     Implements hamlib rigctl network interface so the Kiwi freq & mode can be controlled by these programs.
 * `kiwi_nc`: Command line pipeline tool in the style of `netcat` (unfinished).
 
@@ -50,7 +50,7 @@ It provides the following methods which can be used in derived classes:
 * The complete list of options can be obtained by `python kiwirecorder.py --help`.
 * It is possible to record from more than one KiwiSDR simultaneously, see again `--help`.
 * For recording IQ samples there is the `-w` or `--kiwi-wav` option: this write	a .wav file which includes GNSS	timestamps (see below).
-* AGC options can be specified in a YAML-formatted file, `--agc-yaml` option, see `default_agc.yaml`.
+* AGC options can be specified in a YAML-formatted file, `--agc-yaml` option, see `default_agc.yaml`. Note that this option needs PyYAML to be installed
 
 ## IQ .wav files with GNSS timestamps
 ### kiwirecorder.py configuration
@@ -61,4 +61,3 @@ It provides the following methods which can be used in derived classes:
 ### Working with the recorded .wav files
 * There is an octave extension for reading such WAV files, see `read_kiwi_wav.cc` where the details of the non-standard WAV chunk can be found; it needs to be compiled in this way `mkoctfile read_kiwi_wav.cc`.
 * For using read_kiwi_wav an octave function `proc_kiwi_iq_wav.m` is provided; type `help proc_kiwi_iq_wav` in octave for documentation.
-

--- a/default_agc.yaml
+++ b/default_agc.yaml
@@ -1,0 +1,7 @@
+AGC :
+ 'on':   False ## beware 'on' vs on
+ hang:   False
+ thresh:  -100
+ slope:      6
+ decay:   1000
+ gain:      50

--- a/kiwi/client.py
+++ b/kiwi/client.py
@@ -249,6 +249,7 @@ class KiwiSDRStream(KiwiSDRStreamBase):
         self._freq = freq
 
     def set_agc(self, on=False, hang=False, thresh=-100, slope=6, decay=1000, gain=50):
+        logging.debug('set_agc: on=%s hang=%s thresh=%d slope=%d decay=%d gain=%d' % (on, hang, thresh, slope, decay, gain))
         self._send_message('SET agc=%d hang=%d thresh=%d slope=%d decay=%d manGain=%d' % (on, hang, thresh, slope, decay, gain))
 
     def set_squelch(self, sq, thresh):


### PR DESCRIPTION
In order not to add more CMD line options, the AGC parameters are taken from a YAML file, _e.g._,
```yaml
AGC :
 'on':   False ## beware 'on' vs on
 hang:   False
 thresh:  -100
 slope:      6
 decay:   1000
 gain:      50
```

```
./kiwirecorder.py  --agc-yaml default_agc.yaml --log-level=debug
```

Eventually all CMD line options could be made configurable by a YAML file.