### PR TITLE
workaround for bug in the python libsamplerate binding / added a kiwi iq to .c2 file conversion script for WSPR

### DIFF
--- a/kiwi_iq_wav_to_c2.py
+++ b/kiwi_iq_wav_to_c2.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 import soundfile,struct,sys
 import numpy as np

--- a/kiwi_iq_wav_to_c2.py
+++ b/kiwi_iq_wav_to_c2.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+
+import soundfile,struct,sys
+import numpy as np
+
+## convert kiwirecorder IQ wav files to .c2 file for wsprd
+
+def decode_kiwi_wav_filename(fn):
+    """ input:  kiwirecorder wav file name
+        output: .c2 filename (length 14) and frequency in kHz"""
+    fields = fn.split('/')[-1].split('_')
+    date_and_time = fields[0]
+    c2_filename = date_and_time[2:8] + '_' + date_and_time[9:13] + '.c2'
+    freq_kHz = int(fields[1])/1e3
+    return c2_filename,freq_kHz
+
+def convert_kiwi_wav_to_c2(fn):
+    """ input:  kiwirecorder IQ wav file name with sample rate 375 Hz
+        output: .c2 file for wsprd"""
+    c2_filename,freq_kHz = decode_kiwi_wav_filename(fn)
+    iq,fs = soundfile.read(fn)
+    assert(fs == 375) ## sample rate has to be 375 Hz
+    assert(iq.shape[1] == 2) ## works only for IQ mode recordings
+    iq[:,1] *= -1
+    iq.resize((45000,2), refcheck=False)
+    f = open(c2_filename, 'wb')
+    f.write(struct.pack('<14sid', c2_filename.encode(), 2, freq_kHz))
+    f.write(iq.astype(np.float32).flatten().tobytes())
+    f.close()
+    print('in=' + fn + ' out='+c2_filename)
+
+if __name__ == '__main__':
+    if len(sys.argv) == 1:
+        print('convert kiwirecorder IQ wav files to .c2 file for wsprd')
+        print('USAGE: ' + sys.argv[0]+ ' .wav filenames')
+    for fn in sys.argv[1:]:
+        convert_kiwi_wav_to_c2(fn)
+

--- a/kiwirecorder.py
+++ b/kiwirecorder.py
@@ -16,7 +16,7 @@ try:
     ## needed for the --agc-yaml option
     import yaml
     if yaml.__version__.split('.')[0] != '5':
-        logging.fatal('wrong PyYaml version: pip install pyaml / pip3 install pyyaml (NO SUDO)')
+        print('wrong PyYAML version: %s != 5; PyYAML is only needed when using the --agc-yaml option' % yaml.__version__)
         raise ImportError
 except ImportError:
     ## (only) when needed an exception is raised, see below

--- a/kiwirecorder.py
+++ b/kiwirecorder.py
@@ -182,12 +182,23 @@ class KiwiSoundRecorder(KiwiSDRStream):
         if self._squelch:
             self._squelch.set_sample_rate(self._sample_rate)
         if self._options.resample > 0:
-            self._output_sample_rate = self._options.resample
-            self._ratio = float(self._output_sample_rate)/self._sample_rate
-            logging.info('resampling from %g to %d Hz (ratio=%f)' % (self._sample_rate, self._options.resample, self._ratio))
             if not HAS_RESAMPLER:
+                self._output_sample_rate = self._options.resample
+                self._ratio = float(self._output_sample_rate)/self._sample_rate
                 logging.info("libsamplerate not available: linear interpolation is used for low-quality resampling. "
-                             "(pip install samplerate)")
+                             "(pip/pip3 install samplerate)")
+                logging.info('resampling from %g to %d Hz (ratio=%f)' % (self._sample_rate, self._options.resample, self._ratio))
+            else:
+                fs = 10*round(self._sample_rate/10) ## rounded sample rate
+                ratio = self._options.resample / fs
+                ## work around a bug in python-libsamplerate:
+                ##  the following makes sure that ratio * 512 is an integer
+                ##  at the expense of resampling frequency precision for some resampling frequencies (it's ok for 375 Hz)
+                n = 512 ## KiwiSDR block length for samples
+                m = round(ratio*n)
+                self._ratio = m/n
+                self._output_sample_rate = self._ratio * self._sample_rate
+                logging.info('resampling from %g to %g Hz (ratio=%f)' % (self._sample_rate, self._output_sample_rate, self._ratio))
 
     def _process_audio_samples(self, seq, samples, rssi):
         if self._options.quiet is False:
@@ -237,7 +248,7 @@ class KiwiSoundRecorder(KiwiSDRStream):
                 if self._resampler is None:
                     self._resampler = Resampler(channels=2, converter_type='sinc_best')
                 s = self._resampler.process(s.reshape(len(samples),2), ratio=self._ratio)
-                s = np.round(s.reshape(1, np.size(s))).astype(np.int16)
+                s = np.round(s.flatten()).astype(np.int16)
             else:
                 ## resampling by linear interpolation
                 n  = len(samples)


### PR DESCRIPTION
This allows to record IQ wav files with sample rate 375 Hz with correct downsampling and to convert the recorded IQ files to `.c2` files as an input to `wsprd`.