### PR TITLE
kiwi_nc: fix I/Q samples processing

### DIFF
--- a/kiwi_nc.py
+++ b/kiwi_nc.py
@@ -114,17 +114,10 @@ class KiwiNetcat(KiwiSDRStream):
                     return
             self._write_samples(samples, {})
 
-    def _process_iq_samples_raw(self, seq, samples, rssi, gps):
-        if self._squelch:
-            is_open = self._squelch.process(seq, rssi)
-            if not is_open:
-                self._start_ts = None
-                self._start_time = None
-                return
-        s = array.array('h')
-        for x in [[y.real, y.imag] for y in samples]:
-            s.extend(map(int, x))
-        self._write_samples(s, gps)
+    def _process_iq_samples_raw(self, seq, data):
+        count = len(data) // 2
+        samples = np.ndarray(count, dtype='>h', buffer=data).astype(np.int16)
+        self._write_samples(samples, {})
 
     def _process_waterfall_samples_raw(self, samples, seq):
         if self._options.progress is True:


### PR DESCRIPTION
kiwi_nc.py fails to handle I/Q samples:

- `_process_iq_samples_raw()` function signature is wrong
- squelch is not applicable to I/Q data
- this function is given raw bytes, not complex samples.

This fix is by no means comprehensive - it's just a minimal tweak that I needed to get kiwi_nc.py to work with [dumphfdl](https://github.com/szpajder/dumphfdl). Please apply. Thank you.