### PR TITLE
Scan option added

### DIFF
--- a/kiwirecorder.py
+++ b/kiwirecorder.py
@@ -30,6 +30,8 @@ except ImportError:
     ## otherwise linear interpolation is used
     HAS_RESAMPLER = False
 
+if os.environ['USE_LIBSAMPLERATE'] == 'False':
+    HAS_RESAMPLER = False
 
 def _write_wav_header(fp, filesize, samplerate, num_channels, is_kiwi_wav):
     fp.write(struct.pack('<4sI4s', b'RIFF', filesize - 8, b'WAVE'))

--- a/kiwirecorder.py
+++ b/kiwirecorder.py
@@ -30,8 +30,11 @@ except ImportError:
     ## otherwise linear interpolation is used
     HAS_RESAMPLER = False
 
-if os.environ['USE_LIBSAMPLERATE'] == 'False':
-    HAS_RESAMPLER = False
+try:
+    if os.environ['USE_LIBSAMPLERATE'] == 'False':
+        HAS_RESAMPLER = False
+except KeyError:
+    pass
 
 def _write_wav_header(fp, filesize, samplerate, num_channels, is_kiwi_wav):
     fp.write(struct.pack('<4sI4s', b'RIFF', filesize - 8, b'WAVE'))

--- a/kiwirecorder.py
+++ b/kiwirecorder.py
@@ -835,6 +835,7 @@ def main():
                 options.scan_state = 'WAIT'
                 options.scan_time = time.time()
                 options.scan_index = 0
+                options.scan_yaml['frequencies'] = [float(f) for f in options.scan_yaml['frequencies']]
                 options.frequency = options.scan_yaml['frequencies'][0]
         except KeyError:
             options.scan_yaml = None

--- a/scan.yaml
+++ b/scan.yaml
@@ -1,0 +1,5 @@
+Scan:
+ threshold:  15 # dB
+ wait:        1 # seconds
+ dwell:       4 # seconds
+ frequencies: [6661, 6559, 6311, 8948, 8912] # kHz


### PR DESCRIPTION
This PR adds the option `--scan-yaml=scan.yaml`

An example for a scan YAML file is 
```yaml
Scan:
 threshold:  15 # dB
 wait:        1 # seconds
 dwell:       4 # seconds
 frequencies: [6661, 6559, 6311, 8948, 8912] # kHz
```

 - In this example, all frequencies are scanned for 5 seconds, discarding the 1st second in order to avoid overlap when the frequency is being changed. 
 - There are as many squelch instantiations as there are scan frequencies. 
 - When the squelch opens (threshold setting) the samples are written into a .wav file until the squelch closes; only then the next frequency is set.