### PR TITLE
Starting with python 3.6, the Iterator method is part of the

### DIFF
--- a/kiwi/wavreader.py
+++ b/kiwi/wavreader.py
@@ -1,6 +1,9 @@
 # -*- python -*-
 
-import collections
+try:
+    import collections.abc as collectionsAbc # python 3.6+
+except ImportError:
+    import collections as collectionsAbc
 import struct
 import numpy as np
 from chunk import Chunk
@@ -8,7 +11,7 @@ from chunk import Chunk
 class KiwiIQWavError(Exception):
     pass
 
-class KiwiIQWavReader(collections.Iterator):
+class KiwiIQWavReader(collectionsAbc.Iterator):
     def __init__(self, f):
         super(KiwiIQWavReader, self).__init__()
         self._frame_counter = 0

--- a/kiwiclientd.py
+++ b/kiwiclientd.py
@@ -35,7 +35,7 @@ class KiwiSoundRecorder(KiwiSDRStream):
         self._options = options
         self._type = 'SND'
         freq = options.frequency
-        options.S_meter = False
+        options.S_meter = -1
         options.stats = False
         #logging.info("%s:%s freq=%d" % (options.server_host, options.server_port, freq))
         self._freq = freq


### PR DESCRIPTION
Fix collections.Iterator import for python 3.10

collections.abc class. Starting with python 3.10, the old
collections.Iterator class is gone.

Use the new collections.abc.Iterator class where available, and
fall back to the old collections.Iterator class on older versions.

Signed-off-by: Rik van Riel <riel@surriel.com>