### PR TITLE
Set correct user defined passbands for LSB, AM, and AMn modes.

### DIFF
--- a/kiwi_nc.py
+++ b/kiwi_nc.py
@@ -108,6 +108,12 @@ class KiwiNetcat(KiwiSDRStream):
             if mod == 'am':
                 # For AM, ignore the low pass filter cutoff
                 lp_cut = -hp_cut
+            if mod == 'lsb':
+                # For LSB, transpose and invert the cutoffs
+                lp_cut2 = -hp_cut
+                hp_cut2 = -lp_cut
+                hp_cut = hp_cut2
+                lp_cut = lp_cut2
             self.set_mod(mod, lp_cut, hp_cut, self._freq)
 
             if self._options.agc_gain != None: ## fixed gain (no AGC)

--- a/kiwi_nc.py
+++ b/kiwi_nc.py
@@ -105,15 +105,15 @@ class KiwiNetcat(KiwiSDRStream):
             mod    = self._options.modulation
             lp_cut = self._options.lp_cut
             hp_cut = self._options.hp_cut
-            if mod == 'am':
+            if mod == 'am' or mod == 'amn':
                 # For AM, ignore the low pass filter cutoff
                 lp_cut = -hp_cut
             if mod == 'lsb':
                 # For LSB, transpose and invert the cutoffs
                 lp_cut2 = -hp_cut
                 hp_cut2 = -lp_cut
-                hp_cut = hp_cut2
                 lp_cut = lp_cut2
+                hp_cut = hp_cut2
             self.set_mod(mod, lp_cut, hp_cut, self._freq)
 
             if self._options.agc_gain != None: ## fixed gain (no AGC)

--- a/kiwiclientd.py
+++ b/kiwiclientd.py
@@ -78,16 +78,18 @@ class KiwiSoundRecorder(KiwiSDRStream):
     def _setup_rx_params(self):
         self.set_name(self._options.user)
         lowcut = self._lowcut
-        if self._modulation == 'am':
+        if self._modulation == 'am' or self._modulation == 'amn':
             # For AM, ignore the low pass filter cutoff
             lowcut = -self._highcut if lowcut is not None else lowcut
-        if mod == 'lsb':
-            # For LSB, transpose and invert the cutoffs
-            lp_cut2 = -hp_cut
-            hp_cut2 = -lp_cut
-            hp_cut = hp_cut2
-            lp_cut = lp_cut2
         self.set_mod(self._modulation, lowcut, self._highcut, self._freq)
+        if self._modulation == 'lsb':
+            # For LSB, transpose and invert the cutoffs
+            lowcut2 = -self._highcut
+            hp_cut2 = -self._lowcut
+            highcut = hp_cut2
+            lowcut = lowcut2
+        self.set_mod(self._modulation, lowcut, highcut, self._freq)
+
         if self._options.agc_gain != None:
             self.set_agc(on=False, gain=self._options.agc_gain)
         else:

--- a/kiwiclientd.py
+++ b/kiwiclientd.py
@@ -81,6 +81,12 @@ class KiwiSoundRecorder(KiwiSDRStream):
         if self._modulation == 'am':
             # For AM, ignore the low pass filter cutoff
             lowcut = -self._highcut if lowcut is not None else lowcut
+        if mod == 'lsb':
+            # For LSB, transpose and invert the cutoffs
+            lp_cut2 = -hp_cut
+            hp_cut2 = -lp_cut
+            hp_cut = hp_cut2
+            lp_cut = lp_cut2
         self.set_mod(self._modulation, lowcut, self._highcut, self._freq)
         if self._options.agc_gain != None:
             self.set_agc(on=False, gain=self._options.agc_gain)

--- a/kiwiclientd.py
+++ b/kiwiclientd.py
@@ -80,14 +80,13 @@ class KiwiSoundRecorder(KiwiSDRStream):
         lowcut = self._lowcut
         if self._modulation == 'am' or self._modulation == 'amn':
             # For AM, ignore the low pass filter cutoff
-            lowcut = -self._highcut if lowcut is not None else lowcut
-        self.set_mod(self._modulation, lowcut, self._highcut, self._freq)
+            lowcut = -highcut if lowcut is not None else lowcut
         if self._modulation == 'lsb':
             # For LSB, transpose and invert the cutoffs
-            lowcut2 = -self._highcut
-            hp_cut2 = -self._lowcut
-            highcut = hp_cut2
+            lowcut2 = -highcut
+            highcut2 = -lowcut
             lowcut = lowcut2
+            highcut = highcut2
         self.set_mod(self._modulation, lowcut, highcut, self._freq)
 
         if self._options.agc_gain != None:

--- a/kiwiclientd.py
+++ b/kiwiclientd.py
@@ -78,9 +78,10 @@ class KiwiSoundRecorder(KiwiSDRStream):
     def _setup_rx_params(self):
         self.set_name(self._options.user)
         lowcut = self._lowcut
+        highcut = self._highcut
         if self._modulation == 'am' or self._modulation == 'amn':
             # For AM, ignore the low pass filter cutoff
-            lowcut = -highcut if lowcut is not None else lowcut
+            lowcut = -highcut
         if self._modulation == 'lsb':
             # For LSB, transpose and invert the cutoffs
             lowcut2 = -highcut

--- a/kiwirecorder.py
+++ b/kiwirecorder.py
@@ -168,6 +168,12 @@ class KiwiSoundRecorder(KiwiSDRStream):
         if mod == 'am' or mod == 'amn':
             # For AM, ignore the low pass filter cutoff
             lp_cut = -hp_cut if hp_cut is not None else hp_cut
+        if mod == 'lsb':
+            # For LSB, transpose and invert the cutoffs
+            lp_cut2 = -hp_cut
+            hp_cut2 = -lp_cut
+            hp_cut = hp_cut2
+            lp_cut = lp_cut2
         self.set_mod(mod, lp_cut, hp_cut, self._freq)
 
     def _setup_rx_params(self):

--- a/kiwirecorder.py
+++ b/kiwirecorder.py
@@ -167,13 +167,13 @@ class KiwiSoundRecorder(KiwiSDRStream):
         hp_cut = self._options.hp_cut
         if mod == 'am' or mod == 'amn':
             # For AM, ignore the low pass filter cutoff
-            lp_cut = -hp_cut if hp_cut is not None else hp_cut
+            lp_cut = -hp_cut
         if mod == 'lsb':
             # For LSB, transpose and invert the cutoffs
             lp_cut2 = -hp_cut
             hp_cut2 = -lp_cut
-            hp_cut = hp_cut2
             lp_cut = lp_cut2
+            hp_cut = hp_cut2
         self.set_mod(mod, lp_cut, hp_cut, self._freq)
 
     def _setup_rx_params(self):


### PR DESCRIPTION
While examining code which controls the AM filter, I noticed that proper code to set the filter passband for LSB was not in these scripts.  There are defaults, but a user in LSB mode would not enjoy customized  bandpasses without transposing and inverting the low and high cutoffs.

For AM mode, I simply included AM narrow, which is actually a better match for the audio passbands most users intend to have when setting the high cut value.