### PR TITLE
rigctld: handle incoming commands with \

### DIFF
--- a/kiwi/rigctld.py
+++ b/kiwi/rigctld.py
@@ -168,6 +168,10 @@ class Rigctld(object):
         return message
 
     def _handle_command(self, sock, command):
+        # Remove leading '\' from command
+        if command.startswith("\\"):
+            command = command[1:]
+
         if command.startswith('q'):
             # quit
             try:
@@ -178,7 +182,7 @@ class Rigctld(object):
                 pass
             return "RPRT 0\n"
         elif command.startswith('chk_vfo'):
-            return "0\n"
+            return "CHKVFO 0\n"
         elif command.startswith('get_lock_mode'):
             # unlocked
             return "2\n"

--- a/kiwi/rigctld.py
+++ b/kiwi/rigctld.py
@@ -108,8 +108,19 @@ class Rigctld(object):
     def _set_frequency(self, command):
         try:
             # hamlib freq is in Hz, kiwisdr in kHz
+            # format: F 1234.00000
             newfreq = command[2:]
             freq = float(newfreq) / 1000
+        except:
+            try:
+                # format: F VFOA 1234.00000
+                newfreq = command[7:]
+                freq = float(newfreq) / 1000
+            except:
+                print(f"could not decode frequency from {command}")
+                return "RPRT -1\n"
+
+        try:
             mod = self._kiwisdrstream.get_mod()
             lc = self._kiwisdrstream.get_lowcut()
             hc = self._kiwisdrstream.get_highcut()


### PR DESCRIPTION
It looks like some versions of hamlib send commands preceded by a backslash. We can handle that simply by stripping the backslash from the command before processing it.

Before I got these messages from kiwiclient, and fldigi failed to connect to kiwiclient:

Received unknown command:  \get_powerstat
Received unknown command:  \chk_vfo
Received unknown command:  \dump_state

After this change, I get no error messages, and fldigi connects.

Also fix the chk_vfo command response to match the documented return string from the rigctld(1) man page.