### PR TITLE
update octave function name and remove unused error_state

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ It provides the following methods which can be used in derived classes:
 * If a directory with name `gnss_pos/` exists, a text file `gnss_pos/[name].txt` will be created which contains latitude and longitude as provided by the KiwiSDR; existing files are overwritten.
 
 ### Working with the recorded .wav files
-* There is an octave extension for reading such WAV files, see `read_kiwi_wav.cc` where the details of the non-standard WAV chunk can be found; it needs to be compiled in this way: `mkoctfile read_kiwi_wav.cc`.
-* For using read_kiwi_wav an octave function `proc_kiwi_iq_wav.m` is provided; type `help proc_kiwi_iq_wav` in octave for documentation.
+* There is an octave extension for reading such WAV files, see `read_kiwi_iq_wav.cc` where the details of the non-standard WAV chunk can be found; it needs to be compiled in this way: `mkoctfile read_kiwi_iq_wav.cc`.
+* For using read_kiwi_iq_wav an octave function `proc_kiwi_iq_wav.m` is provided; type `help proc_kiwi_iq_wav` in octave for documentation.
 
 [end-of-document]

--- a/proc_kiwi_iq_wav.m
+++ b/proc_kiwi_iq_wav.m
@@ -32,6 +32,11 @@ function [x,xx,fs,last_gpsfix]=proc_kiwi_iq_wav(fn, max_last_gpsfix)
   ## filter x
   x = x(idx);
   n = numel(x); ## from here on n is always >=2
+  if n<2
+    xx          = {};
+    last_gpsfix = 255;
+    return
+  endif
 
   ## indices of fresh GNSS timestamps
   idx_ts = find(diff(cat(1, x.gpslast)) < 0);

--- a/read_kiwi_iq_wav.cc
+++ b/read_kiwi_iq_wav.cc
@@ -101,8 +101,6 @@ DEFUN_DLD (read_kiwi_iq_wav, args, nargout, "[d,sample_rate]=read_kiwi_wav(\"<wa
   octave_value_list retval;
 
   const std::string filename = args(0).string_value();
-  if (error_state)
-    return retval;
 
   std::ifstream file(filename.c_str(), std::ios::binary);
   if (!file)


### PR DESCRIPTION
Update the name of the .cc file in the README.md for compiling the octave library + remove the error_state variable deprecated since Octave 8 according to https://sourceforge.net/p/octave/tisean/ci/01648917646909b3f9404776475ea65fa60852b0/ (.cc will not compile with Octave 9.4 otherwise)