### PR TITLE
change default block size to 512

### DIFF
--- a/kiwiclientd.py
+++ b/kiwiclientd.py
@@ -629,7 +629,7 @@ def main():
                       help='List available sound devices and exit')
     group.add_option('--bsize', '--blocksize',
                       dest='blocksize',
-                      type='int', default=1024,
+                      type='int', default=512,
                       help='Sound player blocksize (bytes)')
     parser.add_option_group(group)
 


### PR DESCRIPTION
MacOS requires a block size of 512 to work right.

Linux works fine with a block size of 512.

Change the default block size to 512, which works on both.