### PR TITLE
Fix rigctld PKTUSB/CLOSE_WAIT leak, audio player leak, and two client protocol bugs

### DIFF
--- a/kiwi/client.py
+++ b/kiwi/client.py
@@ -373,7 +373,7 @@ class KiwiSDRStream(KiwiSDRStreamBase):
         self._send_message('SET gen=%d mix=%d' % (freq, -1))
 
     def _set_zoom_cf(self, zoom, cf_kHz):
-        if self._kiwi_version >= 1.329:
+        if self._kiwi_version is not None and self._kiwi_version >= 1.329:
             self._send_message('SET zoom=%d cf=%f' % (zoom, cf_kHz))
         else:
             (counter,start_frequency) = self.start_frequency_to_counter(cf_kHz - self.zoom_to_span(zoom)/2)

--- a/kiwi/rigctld.py
+++ b/kiwi/rigctld.py
@@ -29,6 +29,10 @@ class rigsocket(socket.socket):
             # No data available (EAGAIN/EWOULDBLOCK on non-blocking socket)
             return None
 
+        if len(buf) == 0:
+            # peer closed the connection (TCP EOF)
+            return False
+
         try:
             self.buffer += buf.decode('ASCII')
         except (socket.error, UnicodeDecodeError):
@@ -104,12 +108,15 @@ class Rigctld(object):
         try:
             splitcmd = command.split()
             mod = splitcmd[1]
+            if mod.lower() == "pktusb":
+                # FreeDV/hamlib requests Icom-style "packet over USB" mode, which
+                # KiwiSDR has no concept of -- treat it as plain USB.
+                mod = "usb"
             try:
                 hc = int(splitcmd[2])
             except:
                 hc = None
             freq = self._kiwisdrstream.get_frequency()
-            # print("calling set_mod", mod, lc, hc, freq)
             self._kiwisdrstream.set_mod(mod, None, hc, freq)
             return "RPRT 0\n"
         except:
@@ -258,6 +265,13 @@ class Rigctld(object):
             try:
                 command = s.recv_command()
             except socket.error:
+                continue
+
+            if command is False:
+                # peer closed the connection -- close our end too, otherwise
+                # it leaks as a CLOSE_WAIT socket forever
+                s.close()
+                self._clientsockets.remove(s)
                 continue
 
             if command != None and len(command) > 0:

--- a/kiwi/wsclient.py
+++ b/kiwi/wsclient.py
@@ -389,10 +389,14 @@ class ClientHandshakeProcessor(ClientHandshakeBase):
 
             raise ClientHandshakeError('Unexpected extension %r' % extension_name)
 
+        # A server is free to decline an offered extension per the WebSocket
+        # spec -- that's not a handshake failure, just proceed uncompressed.
         if (self._deflate_frame and not deflate_frame_accepted):
-            raise ClientHandshakeError('Requested %s, but the server rejected it' % common.DEFLATE_FRAME_EXTENSION)
+            self._logger.debug('Requested %s, but the server declined it -- continuing uncompressed', common.DEFLATE_FRAME_EXTENSION)
+            self._deflate_frame = False
         if (self._use_permessage_deflate and not permessage_deflate_accepted):
-            raise ClientHandshakeError('Requested %s, but the server rejected it' % common.PERMESSAGE_DEFLATE_EXTENSION)
+            self._logger.debug('Requested %s, but the server declined it -- continuing uncompressed', common.PERMESSAGE_DEFLATE_EXTENSION)
+            self._use_permessage_deflate = False
         
         return None, status_code
 

--- a/kiwiclientd.py
+++ b/kiwiclientd.py
@@ -179,7 +179,7 @@ class KiwiSoundRecorder(KiwiSDRStream):
                 logging.error("Playback error: %s" % e)
 
     def _init_player(self):
-        if hasattr(self, 'player'):
+        if hasattr(self, '_player'):
             self._player.__exit__(exc_type=None, exc_value=None, traceback=None)
         options = self._options
         speaker = sc.get_speaker(options.sounddevice)


### PR DESCRIPTION
## Summary
Four small, independent fixes found while building a downstream tool on top of this client library:

- **kiwiclientd.py**: `_init_player()` checked `hasattr(self, 'player')` but the real attribute is `self._player`, so the old audio player/stream was never closed via `__exit__()` before opening a new one. `_init_player()` re-runs on every sample-rate change, which happens on every mode change (AM/SSB/NBFM have different native rates), so each rigctl mode change leaked a new audio output stream.
- **kiwi/rigctld.py**: `M PKTUSB` (the Icom-style USB-data mode name FreeDV/hamlib sends) wasn't recognized -- KiwiSDR has no such mode, so `set_mod()` raised `KiwiUnknownModulation` and the rigctl command silently failed. Mapped `pktusb` -> `usb`.
- **kiwi/rigctld.py**: `rigsocket.recv_command()` returned the same falsy value (`""`) for both "peer closed the connection" and "garbage received," so `Rigctld.run()` never closed/removed the socket on a real disconnect -- every rigctl client that disconnected (e.g. a controlling app reconnecting) leaked a permanent `CLOSE_WAIT` socket. `recv_command()` now returns `False` specifically for the true-EOF case so `run()` can tell the two apart.
- **kiwi/client.py**: `_set_zoom_cf()` crashed (`TypeError: '>=' not supported between instances of 'NoneType' and 'float'`) if a `sample_rate` message arrived before both `version_maj`/`version_min` had been processed -- observed live against a real Kiwi. Guarded the comparison; an as-yet-unknown version now falls back to the older zoom/start protocol.
- **kiwi/wsclient.py**: `ClientHandshakeProcessor.handshake()` treated a server declining an offered `deflate_frame`/`permessage-deflate` WebSocket extension as a fatal handshake error. Per the WebSocket protocol, offering an extension is optional and a server is free to decline it -- the client should just continue without it.

## Test plan
- [ ] `kiwiclientd.py` against a Kiwi with rigctl frequency/mode changes in flight -- confirm no growing number of audio output streams over time
- [ ] rigctl client sending `M PKTUSB ...` -- confirm it's accepted (was previously always `RPRT -1`)
- [ ] Connect/disconnect several rigctl clients in a row -- confirm no `CLOSE_WAIT` sockets accumulate on the rigctld port
- [ ] Exercise a connection where `sample_rate` can race ahead of version messages -- confirm no crash